### PR TITLE
Support parameterized types

### DIFF
--- a/src/main/java/org/jusecase/builders/generator/PropertiesResolver.java
+++ b/src/main/java/org/jusecase/builders/generator/PropertiesResolver.java
@@ -73,18 +73,26 @@ public class PropertiesResolver {
         public boolean isSetter;
 
         public String getTypeString() {
-            return printType(type);
+            return printType(type, true);
         }
 
         private String printType(Type type) {
-            if (isParametrizedType(type)) {
-           ParameterizedType parameterizedType = (ParameterizedType)type;
-           String params = Arrays.stream(parameterizedType.getActualTypeArguments()).map(this::printType).collect(Collectors.joining(","));
-           return printType(parameterizedType.getRawType()) + "<"  + params + ">";
+            return printType(type, false);
+      }
+
+      private String printType( Type type, boolean unwrapArrayToVararg ) {
+         if ( isParametrizedType(type) ) {
+            ParameterizedType parameterizedType = (ParameterizedType)type;
+            String params = Arrays.stream(parameterizedType.getActualTypeArguments()).map(this::printType).collect(Collectors.joining(","));
+            return printType(parameterizedType.getRawType()) + "<" + params + ">";
          }
          if (isArray(type)) {
                 Type elementType = getArrayElementType(type);
-                return printType(elementType) + " ...";
+                if (unwrapArrayToVararg) {
+               return printType(elementType) + " ...";
+            } else {
+               return printType(elementType) + "[]";
+            }
             } else if (isJavaLangType(type)) {
                 return ((Class<?>) type).getSimpleName();
             } else if (isClass(type)) {

--- a/src/main/java/org/jusecase/builders/generator/PropertiesResolver.java
+++ b/src/main/java/org/jusecase/builders/generator/PropertiesResolver.java
@@ -71,17 +71,28 @@ public class PropertiesResolver {
         public boolean isSetter;
 
         public String getTypeString() {
-            String typeName;
+            return printType(type);
+        }
 
+        private String printType(Type type) {
             if (isArray(type)) {
-              typeName = type.getTypeName();
-            } else if ( isJavaLangType(type) ) {
-                typeName = ((Class<?>) type).getSimpleName();
+                Type elementType = getArrayElementType(type);
+                return printType(elementType) + " ...";
+            } else if (isJavaLangType(type)) {
+                return ((Class<?>) type).getSimpleName();
+            } else if (isClass(type)) {
+                return ((Class<?>) type).getCanonicalName();
             } else {
-                typeName = type.getTypeName();
+                return type.getTypeName();
             }
+        }
 
-            return correctTypeName(typeName);
+        private Type getArrayElementType(Type type) {
+            return ((Class<?>) type).getComponentType();
+        }
+
+        private static boolean isClass(Type type) {
+            return type instanceof Class<?>;
         }
 
         private static boolean isJavaLangType(Type type) {
@@ -126,22 +137,6 @@ public class PropertiesResolver {
             return result;
         }
 
-        private String correctTypeName(String typeName) {
-            typeName = correctNestedTypeName(typeName);
-            typeName = correctArrayTypeName(typeName);
-            return typeName;
-        }
-
-        private String correctArrayTypeName(String typeName) {
-            if (typeName.endsWith("[]")) {
-                typeName = typeName.substring(0, typeName.length() - 2) + " ...";
-            }
-            return typeName;
-        }
-
-        private String correctNestedTypeName(String typeName) {
-            return typeName.replace('$', '.');
-        }
 
         public String nameStartingWithUppercase() {
             return ("" + name.charAt(0)).toUpperCase() +  name.substring(1);

--- a/src/main/java/org/jusecase/builders/generator/PropertiesResolver.java
+++ b/src/main/java/org/jusecase/builders/generator/PropertiesResolver.java
@@ -3,6 +3,7 @@ package org.jusecase.builders.generator;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
 import java.util.*;
 
 public class PropertiesResolver {
@@ -65,22 +66,38 @@ public class PropertiesResolver {
     }
 
     public static class Property implements Comparable<Property> {
-        public String name;
-        public Class<?> type;
+        public String  name;
+        public Type    type;
         public boolean isSetter;
 
         public String getTypeString() {
             String typeName;
 
-            if (type.getName().startsWith("[L")) {
-                typeName = type.getName().substring(2, type.getName().length() - 1) + "[]";
-            } else if (type.getPackage() == null || "java.lang".equals(type.getPackage().getName())) {
-                typeName = type.getSimpleName();
+            if (isArray(type)) {
+              typeName = type.getTypeName();
+            } else if ( isJavaLangType(type) ) {
+                typeName = ((Class<?>) type).getSimpleName();
             } else {
-                typeName = type.getName();
+                typeName = type.getTypeName();
             }
 
             return correctTypeName(typeName);
+        }
+
+        private static boolean isJavaLangType(Type type) {
+            if (type instanceof Class<?>) {
+                Class<?> clazz = (Class<?>)type;
+                 return clazz.getPackage() == null || "java.lang".equals(clazz.getPackage().getName());
+            }
+            return false;
+        }
+
+        private static boolean isArray( Type type ) {
+            if (type instanceof Class<?>) {
+                Class<?> clazz = (Class<?>)type;
+                return clazz.isArray();
+            }
+            return false;
         }
 
         @Override
@@ -104,7 +121,7 @@ public class PropertiesResolver {
         public int compareTo(Property o) {
             int result = name.compareTo(o.name);
             if (result == 0) {
-                result = type.getName().compareTo(o.type.getName());
+                result = type.getTypeName().compareTo(o.type.getTypeName());
             }
             return result;
         }

--- a/src/test/java/org/jusecase/builders/generator/BuilderGeneratorTest.java
+++ b/src/test/java/org/jusecase/builders/generator/BuilderGeneratorTest.java
@@ -132,6 +132,13 @@ public class BuilderGeneratorTest {
       thenGeneratedBuilderIsEqualTo("EntityWithTypedList.expected.txt");
    }
 
+   @Test
+   public void entityWithNestedArray() {
+        givenEntityClass(EntityWithNestedArray.class);
+        whenBuilderIsGenerated();
+        thenGeneratedBuilderIsEqualTo("EntityWithNestedArray.expected.txt");
+   }
+
 
    private void givenEntityClass(Class<?> entityClass) {
         this.entityClass = entityClass;

--- a/src/test/java/org/jusecase/builders/generator/BuilderGeneratorTest.java
+++ b/src/test/java/org/jusecase/builders/generator/BuilderGeneratorTest.java
@@ -118,7 +118,22 @@ public class BuilderGeneratorTest {
         thenGeneratedBuilderIsEqualTo("EntityWithTypedArray.expected.txt");
     }
 
-    private void givenEntityClass(Class<?> entityClass) {
+   @Test
+   public void entityWithTypedArrayList() {
+      givenEntityClass(EntityWithTypedArrayList.class);
+      whenBuilderIsGenerated();
+      thenGeneratedBuilderIsEqualTo("EntityWithTypedArrayList.expected.txt");
+   }
+
+   @Test
+   public void entityWithTypedList() {
+      givenEntityClass(EntityWithTypedList.class);
+      whenBuilderIsGenerated();
+      thenGeneratedBuilderIsEqualTo("EntityWithTypedList.expected.txt");
+   }
+
+
+   private void givenEntityClass(Class<?> entityClass) {
         this.entityClass = entityClass;
     }
 

--- a/src/test/java/org/jusecase/builders/generator/oddities/EntityWithNestedArray.java
+++ b/src/test/java/org/jusecase/builders/generator/oddities/EntityWithNestedArray.java
@@ -1,0 +1,10 @@
+package org.jusecase.builders.generator.oddities;
+
+public class EntityWithNestedArray {
+
+   private String[][] _values;
+
+   public void setValues(String[][] values) {
+      this._values = values;
+   }
+}

--- a/src/test/java/org/jusecase/builders/generator/oddities/EntityWithTypedArrayList.java
+++ b/src/test/java/org/jusecase/builders/generator/oddities/EntityWithTypedArrayList.java
@@ -1,0 +1,11 @@
+package org.jusecase.builders.generator.oddities;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+@SuppressWarnings("unused")
+public class EntityWithTypedArrayList {
+
+   public ArrayList<Integer> values;
+}

--- a/src/test/java/org/jusecase/builders/generator/oddities/EntityWithTypedList.java
+++ b/src/test/java/org/jusecase/builders/generator/oddities/EntityWithTypedList.java
@@ -1,0 +1,10 @@
+package org.jusecase.builders.generator.oddities;
+
+import java.util.List;
+
+
+@SuppressWarnings("unused")
+public class EntityWithTypedList {
+
+   public List<Integer> values;
+}

--- a/src/test/resources/EntityWithNestedArray.expected.txt
+++ b/src/test/resources/EntityWithNestedArray.expected.txt
@@ -1,0 +1,18 @@
+package org.jusecase.builders.generator.oddities;
+
+import org.jusecase.builders.Builder;
+
+@javax.annotation.Generated(value="jusecase-builders-generator")
+public interface EntityWithNestedArrayBuilderMethods<T extends EntityWithNestedArray, B extends Builder> extends Builder<T> {
+    @Override
+    default T build() {
+        return getEntity();
+    }
+
+    T getEntity();
+
+    default B withValues(String[] ... value) {
+        getEntity().setValues(value);
+        return (B)this;
+    }
+}

--- a/src/test/resources/EntityWithTypedArrayList.expected.txt
+++ b/src/test/resources/EntityWithTypedArrayList.expected.txt
@@ -1,0 +1,18 @@
+package org.jusecase.builders.generator.oddities;
+
+import org.jusecase.builders.Builder;
+
+@javax.annotation.Generated(value="jusecase-builders-generator")
+public interface EntityWithTypedArrayListBuilderMethods<T extends EntityWithTypedArrayList, B extends Builder> extends Builder<T> {
+    @Override
+    default T build() {
+        return getEntity();
+    }
+
+    T getEntity();
+
+    default B withValues(java.util.ArrayList<Integer> value) {
+        getEntity().values = value;
+        return (B)this;
+    }
+}

--- a/src/test/resources/EntityWithTypedList.expected.txt
+++ b/src/test/resources/EntityWithTypedList.expected.txt
@@ -1,0 +1,18 @@
+package org.jusecase.builders.generator.oddities;
+
+import org.jusecase.builders.Builder;
+
+@javax.annotation.Generated(value="jusecase-builders-generator")
+public interface EntityWithTypedListBuilderMethods<T extends EntityWithTypedList, B extends Builder> extends Builder<T> {
+    @Override
+    default T build() {
+        return getEntity();
+    }
+
+    T getEntity();
+
+    default B withValues(java.util.List<Integer> value) {
+        getEntity().values = value;
+        return (B)this;
+    }
+}


### PR DESCRIPTION
Currently, the generated usecase builders for a class like this:
```java
class Foo {
    public List<String> values;
}
```
look like this:
```java
public interface FooBuilderMethods<...> {
    default B withValues(java.util.List values) { ... }
}
```

which is suboptimal as it loses type information and might lead to incorrect tests.

With the changes of this PR, the generated builder method would be:
```java
public interface FooBuilderMethods<...> {
    default B withValues(java.util.List<String> values) { ... }
}
```

